### PR TITLE
"Fix" macro name conflicts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@
 build*/
 .vscode/
 cmake-build-*
+cmake-install-*
 phylanx.egg-info/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ cmake_minimum_required(VERSION 3.3.2 FATAL_ERROR)
 # explicitly set certain policies
 cmake_policy(VERSION 3.3.2)
 
+set(CMAKE_CXX_STANDARD 17)
+
 ################################################################################
 # Build type (needs to be handled before project command below)
 ################################################################################

--- a/plugin/halide_plugin.cpp
+++ b/plugin/halide_plugin.cpp
@@ -3,10 +3,10 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include "halide_plugin.hpp"
+
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/plugin_factory.hpp>
-
-#include "halide_plugin.hpp"
 
 PHYLANX_REGISTER_PLUGIN_MODULE();
 

--- a/plugin/harris.cpp
+++ b/plugin/harris.cpp
@@ -3,6 +3,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include<hpx/config.hpp>
+
 #include <Halide.h>
 
 #include "harris.h"

--- a/plugin/harris.cpp
+++ b/plugin/harris.cpp
@@ -3,13 +3,16 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <Halide.h>
+
+#include "harris.h"
+#include "harris.hpp"
+
 #include <phylanx/config.hpp>
 
 #include <hpx/exception.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
-
-#include <Halide.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -17,9 +20,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "harris.h"
-#include "harris.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx_halide_plugin {

--- a/plugin/hpx_runtime.cpp
+++ b/plugin/hpx_runtime.cpp
@@ -1,9 +1,10 @@
+#include <hpx/config.hpp>
+
 #include <Halide.h>
 #include <HalideRuntime.h>
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/iostream.hpp>
-
 #include <hpx/include/parallel_for_loop.hpp>
 
 extern "C" int hpx_halide_do_par_for(void *ctx, int (*f)(void *, int, uint8_t *),

--- a/plugin/hpx_runtime.cpp
+++ b/plugin/hpx_runtime.cpp
@@ -1,10 +1,10 @@
+#include <Halide.h>
+#include <HalideRuntime.h>
+
 #include <hpx/hpx_init.hpp>
 #include <hpx/iostream.hpp>
 
 #include <hpx/include/parallel_for_loop.hpp>
-
-#include <Halide.h>
-#include <HalideRuntime.h>
 
 extern "C" int hpx_halide_do_par_for(void *ctx, int (*f)(void *, int, uint8_t *),
                               int min, int extent, uint8_t *closure) {


### PR DESCRIPTION
This is a frail fix, making sure Halide is included before HPX.